### PR TITLE
Adding information about when to use `self`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1049,7 +1049,7 @@ if (name == "Hello") {
 }
 ```
 
-## Use of self
+## Use of `self`
 
 Don't use `self`, unless your code can't compile without it.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The document uses the [raywenderlich.com Swift styleguide](https://github.com/ra
   * [Failing Guards](#failing-guards)
 * [Semicolons](#semicolons)
 * [Parentheses](#parentheses)
-* [Use of self](#use-of-self)
+* [Use of `self`](#use-of-self)
 
 ## Correctness
 

--- a/README.md
+++ b/README.md
@@ -1053,7 +1053,7 @@ if (name == "Hello") {
 
 Don't use `self`, unless your code can't compile without it.
 
-Use `self` only when required by the compiler (in @escaping closures, or in initializers to disambiguate properties from arguments).
+Use `self` only when required by the compiler (in `@escaping` closures, or in initializers to disambiguate properties from arguments).
 
 ## Further Readings
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ The document uses the [raywenderlich.com Swift styleguide](https://github.com/ra
   * [Failing Guards](#failing-guards)
 * [Semicolons](#semicolons)
 * [Parentheses](#parentheses)
+* [Use of self](#use-of-self)
 
 ## Correctness
 
@@ -1047,6 +1048,12 @@ if (name == "Hello") {
   print("World")
 }
 ```
+
+## Use of self
+
+Don't use `self`, unless your code can't compile without it.
+
+Use `self` only when required by the compiler (in @escaping closures, or in initializers to disambiguate properties from arguments).
 
 ## Further Readings
 


### PR DESCRIPTION
- Adds general etiquette about when to use `self` and when to avoid it.